### PR TITLE
AppIcon for watchOS

### DIFF
--- a/contents.go
+++ b/contents.go
@@ -37,13 +37,13 @@ func (ci *ContentsImage) GetScale() int {
 	return factor
 }
 
-func (ci *ContentsImage) GetSize() (int, int) {
+func (ci *ContentsImage) GetSize() (float64, float64) {
 	a := strings.Split(ci.Size, "x")
-	w, err := strconv.Atoi(a[0])
+	w, err := strconv.ParseFloat(a[0], 64)
 	if err != nil {
 		log.Fatalf("Converter(Resize): cannot parse width %s (%s).", a[0], err)
 	}
-	h, err := strconv.Atoi(a[1])
+	h, err := strconv.ParseFloat(a[1], 64)
 	if err != nil {
 		log.Fatalf("Converter(Resize): cannot parse height %s (%s).", a[0], err)
 	}

--- a/contents_test.go
+++ b/contents_test.go
@@ -31,8 +31,23 @@ func (cs *ContentsSuite) Test_should_get_size(c *C) {
 	ci := ContentsImage{}
 	ci.Size = "42x24"
 	w, h := ci.GetSize()
-	c.Check(w, Equals, 42)
-	c.Check(h, Equals, 24)
+	c.Check(w, Equals, 42.0)
+	c.Check(h, Equals, 24.0)
+
+	ci.Size = "27.5x24.5"
+	w, h = ci.GetSize()
+	c.Check(w, Equals, 27.5)
+	c.Check(h, Equals, 24.5)
+
+	ci.Size = "27x24.5"
+	w, h = ci.GetSize()
+	c.Check(w, Equals, 27.0)
+	c.Check(h, Equals, 24.5)
+
+	ci.Size = "27.5x24"
+	w, h = ci.GetSize()
+	c.Check(w, Equals, 27.5)
+	c.Check(h, Equals, 24.0)
 }
 
 func (cs *ContentsSuite) Test_should_get_scale(c *C) {

--- a/dimensions.go
+++ b/dimensions.go
@@ -53,7 +53,7 @@ func (d *Dimensions) Compute(contents *Contents, meta *ContentsImage, sourceRect
 
 func dimensionFromSize(c *ContentsImage) Rect {
 	w, h := c.GetSize()
-	factor := c.GetScale()
+	factor := float64(c.GetScale())
 
 	return Rect{Width: uint(factor * w), Height: uint(factor * h)}
 }


### PR DESCRIPTION
In Apple Watch, `size` of the icon of 42mm for NotificationCenter is `"27.5x27.5"`:
```
    {
      "size" : "27.5x27.5",
      "idiom" : "watch",
      "filename" : "Icon-27@2x.png",
      "scale" : "2x",
      "role" : "notificationCenter",
      "subtype" : "42mm"
   },
```
`GetSize`, therefore, should return floating point.
